### PR TITLE
Update dependency regarding ipex-llm version

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-ipex-llm/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ipex-llm/pyproject.toml
@@ -35,7 +35,7 @@ version = "0.1.0"
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 llama-index-core = "^0.10.0"
-ipex-llm = {allow-prereleases = true, version = "*"}
+ipex-llm = {allow-prereleases = true, version = ">=2.1.0b20240409"}
 py-cpuinfo = "*"
 protobuf = "*"
 intel-openmp = {markers = "platform_machine=='x86_64' or platform_machine == 'AMD64'", version = "*"}


### PR DESCRIPTION
# Description

For support `sentence-transformers`, `ipex-llm` should >= 2.1.0b20240409
https://github.com/intel-analytics/ipex-llm/commit/dcb2038aad123e3c7a852edf6f0f74489d597217