### PR TITLE
update load low-bit model support and API usage example.

### DIFF
--- a/docs/docs/examples/llm/ipex_llm.ipynb
+++ b/docs/docs/examples/llm/ipex_llm.ipynb
@@ -88,23 +88,55 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Load the Zephyr model locally using IpexLLM."
+    "## Basic Usage\n",
+    "\n",
+    "Load the Zephyr model locally using IpexLLM using `IpexLLM.from_model_id`. It will load the model directly in its Huggingface format and convert it automatically to low-bit format for inference."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3665a56541d541a7a1f285953d2c8a2a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading checkpoint shards:   0%|          | 0/8 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-04-11 21:36:54,739 - INFO - Converting the current model to sym_int4 format......\n"
+     ]
+    }
+   ],
    "source": [
+    "import warnings\n",
+    "\n",
+    "warnings.filterwarnings(\n",
+    "    \"ignore\", category=UserWarning, message=\".*padding_mask.*\"\n",
+    ")\n",
+    "\n",
     "from llama_index.llms.ipex_llm import IpexLLM\n",
     "\n",
     "llm = IpexLLM.from_model_id(\n",
-    "    model_name=\"HuggingFaceH4/zephyr-7b-alpha\",\n",
-    "    tokenizer_name=\"HuggingFaceH4/zephyr-7b-alpha\",\n",
+    "    model_name=\"/mnt/disk1/models/zephyr-7b-alpha\",\n",
+    "    tokenizer_name=\"/mnt/disk1/models/zephyr-7b-alpha\",\n",
+    "    # model_name=\"HuggingFaceH4/zephyr-7b-alpha\",\n",
+    "    # tokenizer_name=\"HuggingFaceH4/zephyr-7b-alpha\",\n",
     "    context_window=512,\n",
     "    max_new_tokens=128,\n",
-    "    generate_kwargs={\"temperature\": 0.7, \"do_sample\": False},\n",
+    "    generate_kwargs={\"do_sample\": False},\n",
     "    completion_to_prompt=completion_to_prompt,\n",
     "    messages_to_prompt=messages_to_prompt,\n",
     ")"
@@ -114,7 +146,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You're all set! You can now use IpexLLM for text completion tasks and interactive chat. "
+    "Now you can proceed to use the loaded model for text completion and interactive chat. "
    ]
   },
   {
@@ -128,7 +160,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "in a far-off land, \n",
+      "there was a young girl named Lily. \n",
+      "Lily lived in a small village surrounded by lush green forests and rolling hills. She loved nothing more than spending her days exploring the woods and playing with her animal friends. \n",
+      "One day, while wandering through the forest, Lily stumbled upon a magical tree. The tree was unlike any other she had ever seen. Its trunk was made of shimmering crystal, and its branches were adorned with sparkling jewels. \n",
+      "Lily was immediately drawn to the tree and sat down to admire its beauty. Suddenly,\n"
+     ]
+    }
+   ],
    "source": [
     "completion_response = llm.complete(\"Once upon a time, \")\n",
     "print(completion_response.text)"
@@ -145,7 +189,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "who loved to play with her toys. She had a favorite teddy bear named Ted, and a doll named Dolly. She would spend hours playing with them, imagining all sorts of adventures. One day, she decided to take Ted and Dolly on a real adventure. She packed a backpack with some snacks, a blanket, and a map. They set off on a hike in the nearby woods. The little girl was so excited that she could barely contain her joy. Ted and Dolly were happy to be along for the ride. They walked for what seemed like hours, but the little girl didn't mind"
+     ]
+    }
+   ],
    "source": [
     "response_iter = llm.stream_complete(\"Once upon a time, there's a little girl\")\n",
     "for response in response_iter:\n",
@@ -163,7 +215,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "assistant: The Big Bang Theory is a popular American sitcom that aired from 2007 to 2019. The show follows the lives of two brilliant but socially awkward physicists, Leonard Hofstadter (Johnny Galecki) and Sheldon Cooper (Jim Parsons), and their friends and colleagues, Penny (Kaley Cuoco), Rajesh Koothrappali (Kunal Nayyar), and Howard Wolowitz (Simon Helberg). The show is set in Pasadena, California, and revolves around the characters' work at Caltech and\n"
+     ]
+    }
+   ],
    "source": [
     "from llama_index.core.llms import ChatMessage\n",
     "\n",
@@ -183,7 +243,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AI stands for Artificial Intelligence. It refers to the development of computer systems that can perform tasks that typically require human intelligence, such as learning, reasoning, and problem-solving. AI involves the use of machine learning algorithms, natural language processing, and other advanced techniques to enable computers to understand and respond to human input in a more natural and intuitive way."
+     ]
+    }
+   ],
    "source": [
     "message = ChatMessage(role=\"user\", content=\"What is AI?\")\n",
     "resp = llm.stream_chat([message], max_tokens=256)\n",
@@ -195,9 +263,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Low Bit Model\n",
-    "\n",
-    "You can save the low-bit model and use `from_model_id_low_bit` to load the weights. "
+    "## Save/Load Low-bit Model\n",
+    "Alternatively, you might save the low-bit model to disk once and use `from_model_id_low_bit` instead of `from_model_id` to reload it for later use - even across different machines. It is space-efficient, as the low-bit model demands significantly less disk space than the original model. And `from_model_id_low_bit` is also more efficient than `from_model_id` in terms of speed and memory usage, as it skips the model conversion step."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To save the low-bit model, use `save_low_bit` as follows."
    ]
   },
   {
@@ -206,17 +280,71 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# path to save low-bit model\n",
-    "LOW_BIT_MODEL_PATH = \"./zephyr-7b-alpha-low-bit\"\n",
-    "llm._model.save_low_bit(LOW_BIT_MODEL_PATH)\n",
-    "llm = IpexLLM.from_model_id_low_bit(\n",
-    "    model_name=LOW_BIT_MODEL_PATH,\n",
-    "    tokenizer_name=\"HuggingFaceH4/zephyr-7b-alpha\",\n",
+    "saved_lowbit_model_path = (\n",
+    "    \"./zephyr-7b-alpha-low-bit\"  # path to save low-bit model\n",
+    ")\n",
+    "\n",
+    "llm._model.save_low_bit(saved_lowbit_model_path)\n",
+    "del llm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the model from saved lowbit model path as follows. \n",
+    "> Note that the saved path for the low-bit model only includes the model itself but not the tokenizers. If you wish to have everything in one place, you will need to manually download or copy the tokenizer files from the original model's directory to the location where the low-bit model is saved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-04-11 21:38:06,151 - INFO - Converting the current model to sym_int4 format......\n"
+     ]
+    }
+   ],
+   "source": [
+    "llm_lowbit = IpexLLM.from_model_id_low_bit(\n",
+    "    model_name=saved_lowbit_model_path,\n",
+    "    # tokenizer_name=\"HuggingFaceH4/zephyr-7b-alpha\",\n",
+    "    tokenizer_name=saved_lowbit_model_path,  # copy the tokenizers to saved path if you want to use it this way\n",
     "    context_window=512,\n",
     "    max_new_tokens=64,\n",
     "    completion_to_prompt=completion_to_prompt,\n",
-    "    generate_kwargs={\"temperature\": 0.7, \"do_sample\": False},\n",
+    "    generate_kwargs={\"do_sample\": False},\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try stream completion using the loaded low-bit model. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A large language model (LLM) is a type of artificial intelligence (AI) model that is trained on a massive amount of text data. These models are capable of generating human-like responses to text inputs and can be used for various natural language processing (NLP) tasks, such as text classification, sentiment analysis"
+     ]
+    }
+   ],
+   "source": [
+    "response_iter = llm_lowbit.stream_complete(\"What is Large Language Model?\")\n",
+    "for response in response_iter:\n",
+    "    print(response.delta, end=\"\", flush=True)"
    ]
   }
  ],

--- a/llama-index-integrations/llms/llama-index-llms-ipex-llm/examples/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-ipex-llm/examples/README.md
@@ -23,3 +23,6 @@ The example [more_data_type.py](./more_data_type.py) shows how to use the `load_
 ```bash
 python more_data_type.py -m <path_to_model> -t <path_to_tokenizer> -l <low_bit_format>
 ```
+
+> Note: If you're using [meta-llama/Llama-2-7b-hf](https://huggingface.co/meta-llama/Llama-2-7b-hf) model in this example, it is recommended to use transformers version
+> <=4.34.

--- a/llama-index-integrations/llms/llama-index-llms-ipex-llm/examples/more_data_type.py
+++ b/llama-index-integrations/llms/llama-index-llms-ipex-llm/examples/more_data_type.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
         max_new_tokens=64,
         load_in_low_bit=low_bit,
         completion_to_prompt=completion_to_prompt,
-        generate_kwargs={"temperature": 0.7, "do_sample": False},
+        generate_kwargs={"do_sample": False},
     )
 
     print(

--- a/llama-index-integrations/llms/llama-index-llms-ipex-llm/llama_index/llms/ipex_llm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ipex-llm/llama_index/llms/ipex_llm/base.py
@@ -1,3 +1,7 @@
+# This file is adapted from
+# https://github.com/run-llama/llama_index/blob/main/llama-index-integrations/
+# llms/llama-index-llms-huggingface/llama_index/llms/huggingface/base.py
+
 import logging
 from threading import Thread
 from typing import Any, Callable, List, Optional, Sequence
@@ -186,52 +190,13 @@ class IpexLLM(CustomLLM):
             None.
         """
         model_kwargs = model_kwargs or {}
-        from ipex_llm.transformers import AutoModelForCausalLM
 
         if model:
             self._model = model
         else:
-            if not low_bit_model:
-                try:
-                    if load_in_low_bit:
-                        self._model = AutoModelForCausalLM.from_pretrained(
-                            model_name,
-                            load_in_low_bit=load_in_low_bit,
-                            use_cache=True,
-                            trust_remote_code=True,
-                            **model_kwargs,
-                        )
-                    else:
-                        self._model = AutoModelForCausalLM.from_pretrained(
-                            model_name,
-                            load_in_4bit=load_in_4bit,
-                            use_cache=True,
-                            trust_remote_code=True,
-                            **model_kwargs,
-                        )
-                except Exception:
-                    from ipex_llm.transformers import AutoModel
-
-                    if load_in_low_bit:
-                        self._model = AutoModel.from_pretrained(
-                            model_name, load_in_low_bit=load_in_low_bit, **model_kwargs
-                        )
-                    else:
-                        self._model = AutoModel.from_pretrained(
-                            model_name, load_in_4bit=load_in_4bit, **model_kwargs
-                        )
-            else:
-                try:
-                    self._model = AutoModelForCausalLM.load_low_bit(
-                        model_name,
-                        use_cache=True,
-                        trust_remote_code=True,
-                        **model_kwargs,
-                    )
-                except Exception:
-                    from ipex_llm.transformers import AutoModel
-
-                    self._model = AutoModel.load_low_bit(model_name, **model_kwargs)
+            self._model = self._load_model(
+                low_bit_model, load_in_4bit, load_in_low_bit, model_name, model_kwargs
+            )
 
         if "xpu" in device_map:
             self._model = self._model.to(device_map)
@@ -268,11 +233,14 @@ class IpexLLM(CustomLLM):
         if tokenizer_name != model_name:
             logger.warning(
                 f"The model `{model_name}` and tokenizer `{tokenizer_name}` "
-                f"are different, please ensure that they are compatible."
+                f"are from different paths, please ensure that they are compatible."
             )
 
         # setup stopping criteria
         stopping_ids_list = stopping_ids or []
+
+        if self._tokenizer.pad_token is None:
+            self._tokenizer.pad_token = self._tokenizer.eos_token
 
         class StopOnTokens(StoppingCriteria):
             def __call__(
@@ -340,6 +308,8 @@ class IpexLLM(CustomLLM):
             model_name=model_name,
             load_in_4bit=load_in_4bit,
             load_in_low_bit=load_in_low_bit,
+            model=model,
+            tokenizer=tokenizer,
             device_map=device_map,
             stopping_ids=stopping_ids,
             tokenizer_kwargs=tokenizer_kwargs,
@@ -382,6 +352,8 @@ class IpexLLM(CustomLLM):
             max_new_tokens=max_new_tokens,
             tokenizer_name=tokenizer_name,
             model_name=model_name,
+            model=model,
+            tokenizer=tokenizer,
             device_map=device_map,
             stopping_ids=stopping_ids,
             tokenizer_kwargs=tokenizer_kwargs,
@@ -410,6 +382,61 @@ class IpexLLM(CustomLLM):
             model_name=self.model_name,
             is_chat_model=self.is_chat_model,
         )
+
+    def _load_model(
+        self,
+        low_bit_model: bool,
+        load_in_4bit: bool,
+        load_in_low_bit: str,
+        model_name: str,
+        model_kwargs: Any,
+    ) -> Any:
+        """Attempts to load a model with AutoModelForCausalLM and falls back to AutoModel on failure."""
+        from ipex_llm.transformers import AutoModelForCausalLM, AutoModel
+
+        load_kwargs = {"use_cache": True, "trust_remote_code": True}
+
+        if not low_bit_model:
+            if load_in_low_bit is not None:
+                load_function_name = "from_pretrained"
+                load_kwargs["load_in_low_bit"] = load_in_low_bit
+            else:
+                load_function_name = "from_pretrained"
+                load_kwargs["load_in_4bit"] = load_in_4bit
+        else:
+            load_function_name = "load_low_bit"
+
+        try:
+            # Attempt to load with AutoModelForCausalLM
+            return self._load_model_general(
+                AutoModelForCausalLM,
+                load_function_name,
+                model_name,
+                load_kwargs,
+                model_kwargs,
+            )
+        except Exception:
+            # Fallback to AutoModel if there's an exception
+            return self._load_model_general(
+                AutoModel, load_function_name, model_name, load_kwargs, model_kwargs
+            )
+
+    def _load_model_general(
+        self,
+        model_class: Any,
+        load_function_name: str,
+        model_name: str,
+        load_kwargs,
+        model_kwargs: dict,
+    ) -> Any:
+        """General function to attempt to load a model."""
+        try:
+            load_function = getattr(model_class, load_function_name)
+            return load_function(model_name, **{**load_kwargs, **model_kwargs})
+        except Exception as e:
+            logger.error(
+                f"Failed to load model using {model_class.__name__}.{load_function_name}: {e}"
+            )
 
     def _tokenizer_messages_to_prompt(self, messages: Sequence[ChatMessage]) -> str:
         """
@@ -472,6 +499,7 @@ class IpexLLM(CustomLLM):
             **input_ids,
             max_new_tokens=self.max_new_tokens,
             stopping_criteria=self._stopping_criteria,
+            pad_token_id=self._tokenizer.pad_token_id,
             **self.generate_kwargs,
         )
         completion_tokens = tokens[0][input_ids["input_ids"].size(1) :]
@@ -514,6 +542,7 @@ class IpexLLM(CustomLLM):
             streamer=streamer,
             max_new_tokens=self.max_new_tokens,
             stopping_criteria=self._stopping_criteria,
+            pad_token_id=self._tokenizer.pad_token_id,
             **self.generate_kwargs,
         )
         thread = Thread(target=self._model.generate, kwargs=generation_kwargs)

--- a/llama-index-integrations/llms/llama-index-llms-ipex-llm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ipex-llm/pyproject.toml
@@ -21,7 +21,7 @@ disallow_untyped_defs = true
 # Remove venv skip when integrated with pre-commit
 exclude = ["_static", "build", "examples", "notebooks", "venv"]
 ignore_missing_imports = true
-python_version = "3.9"
+python_version = "3.11"
 
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
@@ -30,7 +30,7 @@ license = "MIT"
 name = "llama-index-llms-ipex-llm"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
- add load low bit model support
- update API usage in examples, i.e. from_model_id, from_low_bit
- refactor code and tested on chatglm (for AutoModel) and llama for AutoModelForCasualLM
- fix pad_token_id to supress the transformer message
- suppress padding_mask warnings in example
- bump version
- change python from 3.9 to 3.11 and tested